### PR TITLE
feat: add EditOrder endpoint and method

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -173,6 +173,7 @@ impl PrivateEndpoints for PrivateApiClient {
         retrieve_export: "RetrieveExport",
         remove_export: "RemoveExport",
         add_order: "AddOrder",
+        edit_order: "EditOrder",
         cancel_order: "CancelOrder",
         cancel_all: "CancelAll",
         cancel_all_after: "CancelAllOrdersAfter",

--- a/src/endpoints.rs
+++ b/src/endpoints.rs
@@ -66,6 +66,7 @@ pub trait PrivateEndpoints {
         retrieve_export,
         remove_export,
         add_order,
+        edit_order,
         cancel_order,
         cancel_all,
         cancel_all_after,


### PR DESCRIPTION
I noticed editing orders wasn't supported and so added it. I tested myself and it seems to work as expected.

Thanks for the calamari :yum:

Docs: https://docs.kraken.com/rest/#tag/Spot-Trading/operation/editOrder